### PR TITLE
feat: Implement `maxBorrow()` based on BTC/ETH ratio from CL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /cache
 /node_modules
 /out
+.idea/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/solmate"]
 	path = lib/solmate
 	url = https://github.com/rari-capital/solmate
+[submodule "lib/chainlink"]
+	path = lib/chainlink
+	url = https://github.com/smartcontractkit/chainlink

--- a/src/Cdp.sol
+++ b/src/Cdp.sol
@@ -60,7 +60,7 @@ contract Cdp {
             /*uint80 answeredInRound*/
         ) = priceFeed.latestRoundData();
         // Make sure CL was updated recently
-        uint16 threshold = 60 * 60 * 3; // Three hours
+        uint16 threshold = 60 * 60 * 4; // Hours
         require(updatedAt > block.timestamp - threshold, "Feed wasn't updated recently");
         return ethToBtcRatio;
     }

--- a/src/Cdp.sol
+++ b/src/Cdp.sol
@@ -46,8 +46,6 @@ contract Cdp {
         COLLATERAL = ERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
         // BTC/ETH Oracle
         priceFeed = AggregatorV3Interface(0xdeb288F737066589598e9214E782fa5A8eD689e8);
-        // Set ratio on Contract deployment
-        setRatio();
     }
 
     /**
@@ -64,14 +62,10 @@ contract Cdp {
         return ethToBtcRatio;
     }
 
-    function setRatio() public {
+    function getRatio() public view returns (uint256) {
         int256 ethToBtcRatio = getLatestRatio();
         require(ethToBtcRatio > 0, "ETH to BTC ratio is negative");
-        ratio = 1e18 * RATIO_DECIMALS / (uint(ethToBtcRatio));
-    }
-
-    function getRatio() public view returns (uint256) {
-        return ratio;
+        return 1e18 * RATIO_DECIMALS / (uint(ethToBtcRatio));
     }
 
     function flash(uint256 amount, ICallbackRecipient target, bytes memory data) external {
@@ -159,7 +153,7 @@ contract Cdp {
     /// Deposited ETH * (ETH / BTC  ratio) = Value
     /// Value * LTV = Max Borrow
     function maxBorrow() public view returns (uint256) {
-        return totalDeposited * ratio * LTV_PERCENTAGE / RATIO_DECIMALS;
+        return totalDeposited * getRatio() * LTV_PERCENTAGE / RATIO_DECIMALS;
     }
 
     function isSolvent() public view returns (bool) {

--- a/src/Cdp.sol
+++ b/src/Cdp.sol
@@ -56,9 +56,12 @@ contract Cdp {
             /*uint80 roundID*/,
             int256 ethToBtcRatio,
             /*uint startedAt*/,
-            /*uint timeStamp*/,
+            uint256 updatedAt,
             /*uint80 answeredInRound*/
         ) = priceFeed.latestRoundData();
+        // Make sure CL was updated recently
+        uint16 threshold = 60 * 60 * 3; // Three hours
+        require(updatedAt > block.timestamp - threshold, "Feed wasn't updated recently");
         return ethToBtcRatio;
     }
 

--- a/src/Cdp.sol
+++ b/src/Cdp.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 // NOTE: Solmate doesn't check for token existence, this may cause bugs if you enable any collateral
 import {SafeTransferLib} from "../lib/solmate/src/utils/SafeTransferLib.sol";
-
+import {AggregatorV3Interface} from "../lib/chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 import {ERC20} from "../lib/solmate/src/tokens/ERC20.sol";
 import {eBTC} from "./eBTC.sol";
 
@@ -39,9 +39,12 @@ contract Cdp {
 
     address owner;
 
+    AggregatorV3Interface internal priceFeed;
+
     constructor(ERC20 collateral) {
         EBTC = new eBTC();
         COLLATERAL = collateral;
+        priceFeed = AggregatorV3Interface(0xdeb288F737066589598e9214E782fa5A8eD689e8);
     }
 
     // NOTE: Unsafe should be protected by governance (tbh should be a feed)

--- a/src/Cdp.sol
+++ b/src/Cdp.sol
@@ -32,8 +32,7 @@ contract Cdp {
 
     uint256 totalBorrowed;
 
-    // Oracle for Ratio
-    uint256 ratio = 3e17; // Conversion rate
+    uint256 ratio = 3e17;
 
     uint256 constant RATIO_DECIMALS = 10 ** 8;
 
@@ -44,12 +43,31 @@ contract Cdp {
     constructor(ERC20 collateral) {
         EBTC = new eBTC();
         COLLATERAL = collateral;
+        // BTC/ETH Oracle
         priceFeed = AggregatorV3Interface(0xdeb288F737066589598e9214E782fa5A8eD689e8);
+    }
+
+    /**
+     * Returns the latest ratio between BTC and ETH
+     */
+    function getLatestRatio() public view returns (int) {
+        (
+            /*uint80 roundID*/,
+            int256 ethToBtcRatio,
+            /*uint startedAt*/,
+            /*uint timeStamp*/,
+            /*uint80 answeredInRound*/
+        ) = priceFeed.latestRoundData();
+        return ethToBtcRatio;
     }
 
     // NOTE: Unsafe should be protected by governance (tbh should be a feed)
     function setRatio(uint256 newRatio) external {
         ratio = newRatio;
+    }
+
+    function getRatio() private view returns (uint256) {
+        return ratio;
     }
 
     function flash(uint256 amount, ICallbackRecipient target, bytes memory data) external {

--- a/src/Cdp.sol
+++ b/src/Cdp.sol
@@ -50,6 +50,7 @@ contract Cdp {
 
     /**
      * Returns the latest ratio between BTC and ETH
+     * TODO: Check before launch: what should be considered as acceptable time range for CL to be updated
      */
     function getLatestRatio() public view returns (int) {
         (
@@ -60,7 +61,7 @@ contract Cdp {
             /*uint80 answeredInRound*/
         ) = priceFeed.latestRoundData();
         // Make sure CL was updated recently
-        uint16 threshold = 60 * 60 * 4; // Hours
+        uint32 threshold = 60 * 60 * 24; // Hours
         require(updatedAt > block.timestamp - threshold, "Feed wasn't updated recently");
         return ethToBtcRatio;
     }

--- a/src/eBTC.sol
+++ b/src/eBTC.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+contract eBTC {
+    address immutable OWNER;
+
+    mapping(address => uint256) balances;
+
+    constructor() {
+        OWNER = msg.sender;
+    }
+
+    function mint(address recipient, uint256 amount) external {
+        balances[recipient] += amount;
+    }
+
+    function balanceOf(address recipient) external view returns (uint256) {
+        return balances[recipient];
+    }
+
+    function burn(address recipient, uint256 amount) external {
+        balances[recipient] -= amount;
+    }
+}

--- a/src/eBTC.sol
+++ b/src/eBTC.sol
@@ -21,4 +21,7 @@ contract eBTC {
     function burn(address recipient, uint256 amount) external {
         balances[recipient] -= amount;
     }
+    function decimals() public view virtual returns (uint8) {
+      return 8;
+    }
 }

--- a/test/Borrow.t.sol
+++ b/test/Borrow.t.sol
@@ -10,9 +10,8 @@ import {Dai} from "../src/Cdp.sol";
 import {ERC20} from "../lib/solmate/src/tokens/ERC20.sol";
 
 
-contract SampleContractTest is Test {
+contract BorrowTest is Test {
     using SafeTransferLib for ERC20;
-
 
     ERC20 public constant BADGER = ERC20(0x3472A5A71965499acd81997a54BBA8D852C6E53d);
 
@@ -44,7 +43,8 @@ contract SampleContractTest is Test {
         // Deposit collateral first
         BADGER.safeApprove(address(cdpContract), collateral_amount);
         cdpContract.deposit(collateral_amount);
-
+        console.log("MAX BORROW");
+        console.log(cdpContract.maxBorrow());
         cdpContract.borrow(amount);
         assert(cdpContract.DAI().balanceOf(user) == amount);
     }

--- a/test/Borrow.t.sol
+++ b/test/Borrow.t.sol
@@ -6,7 +6,6 @@ import "forge-std/Test.sol";
 import {SafeTransferLib} from "../lib/solmate/src/utils/SafeTransferLib.sol";
 
 import {Cdp} from "../src/Cdp.sol";
-import {Dai} from "../src/Cdp.sol";
 import {ERC20} from "../lib/solmate/src/tokens/ERC20.sol";
 
 
@@ -46,7 +45,7 @@ contract BorrowTest is Test {
         console.log("MAX BORROW");
         console.log(cdpContract.maxBorrow());
         cdpContract.borrow(amount);
-        assert(cdpContract.DAI().balanceOf(user) == amount);
+        assert(cdpContract.EBTC().balanceOf(user) == amount);
     }
 
     function testFailBorrowOverLimitNoCollateral() public {
@@ -54,6 +53,6 @@ contract BorrowTest is Test {
         uint256 borrowedAmt = 1000;
         cdpContract.borrow(borrowedAmt);
         // Make sure user didn't borrow anything
-        assert(cdpContract.DAI().balanceOf(user) == 0);
+        assert(cdpContract.EBTC().balanceOf(user) == 0);
     }
 }

--- a/test/Borrow.t.sol
+++ b/test/Borrow.t.sol
@@ -12,7 +12,7 @@ import {ERC20} from "../lib/solmate/src/tokens/ERC20.sol";
 contract BorrowTest is Test {
     using SafeTransferLib for ERC20;
 
-    ERC20 public constant BADGER = ERC20(0x3472A5A71965499acd81997a54BBA8D852C6E53d);
+    ERC20 public constant WETH = ERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
 
     address user;
     uint256 collateral_amount;
@@ -21,14 +21,14 @@ contract BorrowTest is Test {
 
     function getSomeToken() internal {
         vm.prank(0xD0A7A8B98957b9CD3cFB9c0425AbE44551158e9e);
-        BADGER.safeTransfer(address(this), 123e18);
-        assert(BADGER.balanceOf(address(this)) == 123e18);
+        WETH.safeTransfer(address(this), 123e18);
+        assert(WETH.balanceOf(address(this)) == 123e18);
     }
 
     function setUp() public {
-        cdpContract = new Cdp(BADGER);
+        cdpContract = new Cdp();
         user = address(this);
-        collateral_amount = 1337;
+        collateral_amount = 123e18;
     }
 
     function testbasicBorrow(uint32 amount) public {
@@ -40,8 +40,9 @@ contract BorrowTest is Test {
         getSomeToken();
 
         // Deposit collateral first
-        BADGER.safeApprove(address(cdpContract), collateral_amount);
+        WETH.safeApprove(address(cdpContract), collateral_amount);
         cdpContract.deposit(collateral_amount);
+        cdpContract.setRatio();
         cdpContract.borrow(amount);
         assert(cdpContract.EBTC().balanceOf(user) == amount);
     }

--- a/test/Borrow.t.sol
+++ b/test/Borrow.t.sol
@@ -31,11 +31,10 @@ contract BorrowTest is Test {
         collateral_amount = 123e18; // 123 WETH deposited
     }
 
-    function testbasicBorrow(uint32 amount) public {
+    function testbasicBorrow(uint64 amount) public {
         /*
         * Simple fuzz test covering basic borrowing against
         * properly deposited collateral
-        * TODO: Mock Oracle for Cdp.ratio once it's added
         */
         getSomeToken();
 

--- a/test/Borrow.t.sol
+++ b/test/Borrow.t.sol
@@ -17,6 +17,7 @@ contract SampleContractTest is Test {
     ERC20 public constant BADGER = ERC20(0x3472A5A71965499acd81997a54BBA8D852C6E53d);
 
     address user;
+    uint256 collateral_amount;
 
     Cdp cdpContract;
 
@@ -29,6 +30,7 @@ contract SampleContractTest is Test {
     function setUp() public {
         cdpContract = new Cdp(BADGER);
         user = address(this);
+        collateral_amount = 1337;
     }
 
     function testbasicBorrow(uint32 amount) public {
@@ -40,8 +42,8 @@ contract SampleContractTest is Test {
         getSomeToken();
 
         // Deposit collateral first
-        BADGER.safeApprove(address(cdpContract), 1337);
-        cdpContract.deposit(1337);
+        BADGER.safeApprove(address(cdpContract), collateral_amount);
+        cdpContract.deposit(collateral_amount);
 
         cdpContract.borrow(amount);
         assert(cdpContract.DAI().balanceOf(user) == amount);

--- a/test/Borrow.t.sol
+++ b/test/Borrow.t.sol
@@ -50,7 +50,7 @@ contract SampleContractTest is Test {
     }
 
     function testFailBorrowOverLimitNoCollateral() public {
-        // Case when borrowing against no  collateral at all
+        // Case when borrowing against no collateral at all
         uint256 borrowedAmt = 1000;
         cdpContract.borrow(borrowedAmt);
         // Make sure user didn't borrow anything

--- a/test/Borrow.t.sol
+++ b/test/Borrow.t.sol
@@ -31,9 +31,9 @@ contract SampleContractTest is Test {
         user = address(this);
     }
 
-    function testbasicBorrow() public {
+    function testbasicBorrow(uint32 amount) public {
         /*
-        * Simple test covering basic borrowing against
+        * Simple fuzz test covering basic borrowing against
         * properly deposited collateral
         * TODO: Mock Oracle for Cdp.ratio once it's added
         */
@@ -43,13 +43,12 @@ contract SampleContractTest is Test {
         BADGER.safeApprove(address(cdpContract), 1337);
         cdpContract.deposit(1337);
 
-        uint256 borrowedAmt = 1000;
-        cdpContract.borrow(borrowedAmt);
-        assert(cdpContract.DAI().balanceOf(user) == borrowedAmt);
+        cdpContract.borrow(amount);
+        assert(cdpContract.DAI().balanceOf(user) == amount);
     }
 
-    function testFailBorrowOverLimit() public {
-        // Case when borrowing against insufficient amount of collateral
+    function testFailBorrowOverLimitNoCollateral() public {
+        // Case when borrowing against no  collateral at all
         uint256 borrowedAmt = 1000;
         cdpContract.borrow(borrowedAmt);
         // Make sure user didn't borrow anything

--- a/test/Borrow.t.sol
+++ b/test/Borrow.t.sol
@@ -42,7 +42,6 @@ contract BorrowTest is Test {
         // Deposit collateral first
         WETH.safeApprove(address(cdpContract), collateral_amount);
         cdpContract.deposit(collateral_amount);
-        cdpContract.setRatio();
         cdpContract.borrow(amount);
         assert(cdpContract.EBTC().balanceOf(user) == amount);
     }

--- a/test/Borrow.t.sol
+++ b/test/Borrow.t.sol
@@ -7,6 +7,7 @@ import {SafeTransferLib} from "../lib/solmate/src/utils/SafeTransferLib.sol";
 
 
 import {Cdp} from "../src/Cdp.sol";
+import {Dai} from "../src/Cdp.sol";
 import {ERC20} from "../lib/solmate/src/tokens/ERC20.sol";
 
 // Useful links
@@ -23,8 +24,7 @@ contract SampleContractTest is Test {
 
 
     ERC20 public constant BADGER = ERC20(0x3472A5A71965499acd81997a54BBA8D852C6E53d);
-    
-    // Become this guy
+
     address user;
 
     Cdp cdpContract;
@@ -41,17 +41,20 @@ contract SampleContractTest is Test {
         user = address(this);
     }
 
-    function testBasicSetupWorks() public {
-        getSomeToken();
-        assert(cdpContract.COLLATERAL() == BADGER);
-    }
-
-
-    function testBasicDeposit() public {
-        // Test is scoped so you need to re-do setup each test
+    function testbasicBorrow() public {
         getSomeToken();
 
+        // Deposit collateral first
         BADGER.safeApprove(address(cdpContract), 1337);
         cdpContract.deposit(1337);
+
+        uint256 borrowedAmt = 1000;
+        cdpContract.borrow(borrowedAmt);
+        assert(cdpContract.DAI().balanceOf(user) == borrowedAmt);
+    }
+
+    function testFailBorrowOverLimit() public {
+        uint256 borrowedAmt = 1000;
+        cdpContract.borrow(borrowedAmt);
     }
 }

--- a/test/Borrow.t.sol
+++ b/test/Borrow.t.sol
@@ -42,8 +42,6 @@ contract BorrowTest is Test {
         // Deposit collateral first
         BADGER.safeApprove(address(cdpContract), collateral_amount);
         cdpContract.deposit(collateral_amount);
-        console.log("MAX BORROW");
-        console.log(cdpContract.maxBorrow());
         cdpContract.borrow(amount);
         assert(cdpContract.EBTC().balanceOf(user) == amount);
     }

--- a/test/Borrow.t.sol
+++ b/test/Borrow.t.sol
@@ -5,7 +5,6 @@ import "forge-std/Test.sol";
 
 import {SafeTransferLib} from "../lib/solmate/src/utils/SafeTransferLib.sol";
 
-
 import {Cdp} from "../src/Cdp.sol";
 import {Dai} from "../src/Cdp.sol";
 import {ERC20} from "../lib/solmate/src/tokens/ERC20.sol";

--- a/test/Borrow.t.sol
+++ b/test/Borrow.t.sol
@@ -28,7 +28,7 @@ contract BorrowTest is Test {
     function setUp() public {
         cdpContract = new Cdp();
         user = address(this);
-        collateral_amount = 123e18;
+        collateral_amount = 123e18; // 123 WETH deposited
     }
 
     function testbasicBorrow(uint32 amount) public {

--- a/test/Borrow.t.sol
+++ b/test/Borrow.t.sol
@@ -9,14 +9,6 @@ import {Cdp} from "../src/Cdp.sol";
 import {Dai} from "../src/Cdp.sol";
 import {ERC20} from "../lib/solmate/src/tokens/ERC20.sol";
 
-// Useful links
-// How to steal tokens for forknet: 
-// https://github.com/foundry-rs/forge-std/blob/2a2ce3692b8c1523b29de3ec9d961ee9fbbc43a6/src/Test.sol#L118-L150
-// All the basics
-// https://github.com/dabit3/foundry-cheatsheet
-// Foundry manual
-// https://book.getfoundry.sh/cheatcodes/
-
 
 contract SampleContractTest is Test {
     using SafeTransferLib for ERC20;
@@ -29,7 +21,6 @@ contract SampleContractTest is Test {
     Cdp cdpContract;
 
     function getSomeToken() internal {
-        // become whale
         vm.prank(0xD0A7A8B98957b9CD3cFB9c0425AbE44551158e9e);
         BADGER.safeTransfer(address(this), 123e18);
         assert(BADGER.balanceOf(address(this)) == 123e18);
@@ -41,6 +32,11 @@ contract SampleContractTest is Test {
     }
 
     function testbasicBorrow() public {
+        /*
+        * Simple test covering basic borrowing against
+        * properly deposited collateral
+        * TODO: Mock Oracle for Cdp.ratio once it's added
+        */
         getSomeToken();
 
         // Deposit collateral first
@@ -53,7 +49,10 @@ contract SampleContractTest is Test {
     }
 
     function testFailBorrowOverLimit() public {
+        // Case when borrowing against insufficient amount of collateral
         uint256 borrowedAmt = 1000;
         cdpContract.borrow(borrowedAmt);
+        // Make sure user didn't borrow anything
+        assert(cdpContract.DAI().balanceOf(user) == 0);
     }
 }

--- a/test/Cdp.t.sol
+++ b/test/Cdp.t.sol
@@ -60,7 +60,7 @@ contract SampleContractTest is Test {
     function testFailgetLatestRatioCLNotUpdated() public {
         // Test for case when CL wasn't updated for 10 hours, so getLatestRatio must fail
         int256 expRatio = 14802961150000000000;
-        uint16 thresholdToFail = 60 * 60 * 10; // 10 Hours
+        uint32 thresholdToFail = 60 * 60 * 25; // 25 Hours
         // Make sure getLatestRatio() fails when CL wasn't updated recently
         vm.mockCall(
             address(0xdeb288F737066589598e9214E782fa5A8eD689e8),  // CL address

--- a/test/Cdp.t.sol
+++ b/test/Cdp.t.sol
@@ -22,7 +22,7 @@ contract SampleContractTest is Test {
     using SafeTransferLib for ERC20;
 
 
-    ERC20 public constant BADGER = ERC20(0x3472A5A71965499acd81997a54BBA8D852C6E53d);
+    ERC20 public constant WETH = ERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
     
     // Become this guy
     address user;
@@ -30,27 +30,26 @@ contract SampleContractTest is Test {
     Cdp cdpContract;
 
     function getSomeToken() internal {
-        // become whale
-        vm.prank(0xD0A7A8B98957b9CD3cFB9c0425AbE44551158e9e);
-        BADGER.safeTransfer(address(this), 123e18);
-        assert(BADGER.balanceOf(address(this)) == 123e18);
+        vm.prank(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+        WETH.safeTransfer(address(this), 123e18);
+        assert(WETH.balanceOf(address(this)) == 123e18);
     }
 
     function setUp() public {
-        cdpContract = new Cdp(BADGER);
+        cdpContract = new Cdp();
         user = address(this);
     }
 
     function testBasicSetupWorks() public {
         getSomeToken();
-        assert(cdpContract.COLLATERAL() == BADGER);
+        assert(cdpContract.COLLATERAL() == WETH);
     }
 
     function testBasicDeposit() public {
         // Test is scoped so you need to re-do setup each test
         getSomeToken();
 
-        BADGER.safeApprove(address(cdpContract), 1337);
+        WETH.safeApprove(address(cdpContract), 1337);
         cdpContract.deposit(1337);
     }
 

--- a/test/Cdp.t.sol
+++ b/test/Cdp.t.sol
@@ -53,4 +53,10 @@ contract SampleContractTest is Test {
         BADGER.safeApprove(address(cdpContract), 1337);
         cdpContract.deposit(1337);
     }
+
+    function testgetLatestRatio() public view {
+        // Simple test case to check that Oracle doesn't return zero values
+        int ratio = cdpContract.getLatestRatio();
+        assert(ratio != 0);
+    }
 }

--- a/test/Cdp.t.sol
+++ b/test/Cdp.t.sol
@@ -76,9 +76,19 @@ contract SampleContractTest is Test {
         vm.clearMockedCalls();
     }
 
-    function testgetLatestRatio() public view {
+    function testgetLatestRatio() public {
         // Simple test case to check that Oracle doesn't return zero values
+        int256 expRatio = 14802961150000000000;
+        uint256 validThreshold = block.timestamp - 60 * 60 * 1; // 1 Hour, CL was updated recently
+        // Make sure getLatestRatio() fails when CL wasn't updated recently
+        vm.mockCall(
+            address(0xdeb288F737066589598e9214E782fa5A8eD689e8),  // CL address
+            abi.encodeWithSelector(AggregatorV3Interface.latestRoundData.selector),
+            // CL mock data
+            abi.encode(73786976294838207540, expRatio, 1666261667, validThreshold, 73786976294838207540)
+        );
         int ratio = cdpContract.getLatestRatio();
+        assertEq(ratio, expRatio);
         assert(ratio != 0);
     }
 

--- a/test/EbtcTest.sol
+++ b/test/EbtcTest.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import "forge-std/Test.sol";
+import {ERC20} from "../lib/solmate/src/tokens/ERC20.sol";
+import {eBTC} from "../src/eBTC.sol";
+import {Cdp} from "../src/Cdp.sol";
+import {SafeTransferLib} from "../lib/solmate/src/utils/SafeTransferLib.sol";
+import {AggregatorV3Interface} from "../lib/chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+
+
+contract EbtcTest is Test {
+    using SafeTransferLib for ERC20;
+    ERC20 public constant WETH = ERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+
+    address user;
+    eBTC EBTC;
+    Cdp cdpContract;
+
+    function setUp() public virtual {
+        cdpContract = new Cdp();
+        user = address(this);
+        EBTC = new eBTC();
+    }
+
+    function getSomeToken() internal {
+        vm.prank(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+        WETH.safeTransfer(address(this), 500e18);  // Get 500 ETH
+        assert(WETH.balanceOf(address(this)) == 500e18);
+    }
+
+    function mockRateGetterCL(int256 rate, uint256 updatedAt) internal {
+        // Don't forget to do vm.clearMockedCalls(); at the end of each test using this function
+        vm.mockCall(
+            address(0xdeb288F737066589598e9214E782fa5A8eD689e8),  // CL address
+            abi.encodeWithSelector(AggregatorV3Interface.latestRoundData.selector),
+            // CL mock data
+            abi.encode(73786976294838207540, rate, 1666261667, updatedAt, 73786976294838207540)
+        );
+    }
+}

--- a/test/SampleContract.t.sol
+++ b/test/SampleContract.t.sol
@@ -46,7 +46,6 @@ contract SampleContractTest is Test {
         assert(cdpContract.COLLATERAL() == BADGER);
     }
 
-
     function testBasicDeposit() public {
         // Test is scoped so you need to re-do setup each test
         getSomeToken();


### PR DESCRIPTION
**Done**:
1. Add `AggregatorV3Interface` to fetch data from https://data.chain.link/arbitrum/mainnet/crypto-eth/btc-eth oracle
2. Implement `getLatestRatio` with guards against invalid values
3. Implement `maxBorrow` using value from `getLatestRatio`
4. Tests

More tests TBA